### PR TITLE
feat: add maxMessages option to limit number of messages in chat context

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ coba [git-repo-path] [options]
 - `-m, --model <model>`: Pick a language model (e.g. `gpt-4.1-mini` or `magistral:24b`)
 - `-k, --api-key <key>`: Supply API key for remote providers
 - `-u, --api-url <url>`: Set custom API URL
+- `--max-messages <count>`: Limit the number of messages kept in history (default: 10)
 - `-C, --continue-session <file>`: Continue a saved conversation
 - `--write-mode`: Enable write mode from the start
 

--- a/src/coba.tsx
+++ b/src/coba.tsx
@@ -23,6 +23,7 @@ program
 	.option("-u, --api-url <url>", "API URL for the model provider")
 	.option("-k, --api-key <key>", "API key for the model provider")
 	.option("--context-size <size>", "Context size in tokens used for chat history")
+	.option("--max-messages <count>", "Maximum number of messages to keep in chat history", "10")
 	.option("-C, --continue-session <filename>", "Continue with session loaded from filename")
 	.option("--write-mode", "Enable write mode")
 	.option("--no-agent-rules", "Disable loading of AGENTS.md, .cursorrules, etc.")
@@ -37,10 +38,15 @@ program
 			? parseInt(options.contextSize)
 			: (options.provider === "ollama" ? 8192 : undefined);
 
+		const maxMessages = options.maxMessages
+			? parseInt(options.maxMessages)
+			: undefined;
+
 		const chatServiceOptions: IChatServiceOptions = {
 			provider: options.provider,
 			model: options.model,
 			contextSize,
+			maxMessages,
 			apiUrl: options.apiUrl,
 			apiKey: options.apiKey,
 			disableAgentRules: options.noAgentRules,


### PR DESCRIPTION
This PR introduces a new mechanism to limit the chat history sent to the LLM by the number of messages.

This acts as a coarse-grained filter before the existing token-based trimming, providing better control over conversational context.

The feature adds a two-stage trimming process:

1. First, the history is trimmed to a specific number of recent messages.
2. Then, the result is passed to the existing token-based trimming as a safeguard, ensuring the context fits the model's window (by default, this is only done for provider Ollama.)

#### Command-Line Usage

A new command-line option has been added to control this feature:

* `--max-messages <count>`: Sets the maximum number of messages to keep in the chat history. Defaults to `10`.

Example:

```sh
$ coba -p ollama -m llama3 --max-messages 20
```
