### PR TITLE
hotfix: limit message content size before sending to LLM

### DIFF
--- a/src/ai/chat-service.ts
+++ b/src/ai/chat-service.ts
@@ -253,8 +253,6 @@ class ChatService
 
             stored.data.content = stored.data.content.slice(0, truncLimit);
 
-            console.error("LIMIT", msg.text.length, stored.data.content.length);
-
             return mapStoredMessageToChatMessage(stored);
         });
     }

--- a/src/ai/chat-service.ts
+++ b/src/ai/chat-service.ts
@@ -1,5 +1,5 @@
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
-import { BaseMessage, SystemMessage, trimMessages } from "@langchain/core/messages";
+import { BaseMessage, mapChatMessagesToStoredMessages, mapStoredMessageToChatMessage, SystemMessage, trimMessages } from "@langchain/core/messages";
 
 import { COMMIT_HASH, VERSION } from "../.version.js";
 import tryCatch from "../utils/try-catch.js";
@@ -191,6 +191,9 @@ class ChatService
 
         let preparedMessages: BaseMessage[] = messages.filter(msg => msg instanceof BaseMessage);
 
+        // Stage 0: Limit message content size to 50.000 - 60.000 characters
+        preparedMessages = this.limitMessageContentSize(preparedMessages, 60_000);
+
         // Stage 1: Trim by message count
         if (this.current.maxMessages)
         {
@@ -233,6 +236,27 @@ class ChatService
         }
 
         return preparedMessages;
+    }
+
+    private limitMessageContentSize(messages: readonly BaseMessage[], limit: number = 60_000): BaseMessage[]
+    {
+        const truncLimit = Math.trunc(limit * 0.9);
+
+        return messages.map(msg =>
+        {
+            if (msg.text.length < limit)
+            {
+                return msg;
+            }
+
+            const stored = mapChatMessagesToStoredMessages([msg])[0]!; // TODO: fix the !
+
+            stored.data.content = stored.data.content.slice(0, truncLimit);
+
+            console.error("LIMIT", msg.text.length, stored.data.content.length);
+
+            return mapStoredMessageToChatMessage(stored);
+        });
     }
 }
 


### PR DESCRIPTION
This pull request adds a pre-trimming safeguard that caps oversized chat messages (~50k–60k chars) to prevent provider failures and improve reliability.

### 🐛 Bug Fixes
- Add a pre-trimming safeguard that caps individual message content to ~50k–60k characters to avoid exceeding provider/model limits

### ⚙️ Under the Hood
- `chat-service.ts`:
  - New Stage 0: limitMessageContentSize(messages, 60_000) before count/time trimming.
  - Truncates to 90% of the limit when exceeded; uses stored↔chat message mappers for safe mutation.

### 🧯 Risk and Rollback
- Risk level: Low — this change reduces risk of request failures, rate-limit penalties, and degraded latency due to oversized payloads.
- Residual risks: tail content may be cut in extremely long messages; truncation is naive (hard cut).
- Rollback: revert the change or disable the Stage 0 call.
- Mitigations: conservative threshold with 10% headroom; can add summarization or make the limit configurable later.