### PR TITLE
feat: add agent command to run a message and get a response

### DIFF
--- a/src/ai/chat-service.ts
+++ b/src/ai/chat-service.ts
@@ -153,9 +153,9 @@ class ChatService
         return this.current?.tools;
     }
 
-    async stream(session: IChatSession, signal?: AbortSignal)
+    async bindTools(session: IChatSession)
     {
-        const llm = await this.getLLM(session).then(llm => 
+        return await this.getLLM(session).then(llm => 
         {
             if (!this.tools || Object.keys(this.tools).length === 0)
             {
@@ -169,10 +169,24 @@ class ChatService
 
             return llm.bindTools(Object.values(this.tools));
         });
+    }
+
+    async stream(session: IChatSession, signal?: AbortSignal)
+    {
+        const llm = await this.bindTools(session);
 
         const preparedMessages = await this.prepareMessages(session);
 
         return llm.stream(preparedMessages, { signal });
+    }
+
+    async generate(session: IChatSession, signal?: AbortSignal)
+    {
+        const llm = await this.bindTools(session);
+
+        const preparedMessages = await this.prepareMessages(session);
+
+        return llm.invoke(preparedMessages, { signal });
     }
 
     private async prepareMessages(session: IChatSession): Promise<BaseMessage[]>

--- a/src/ai/custom-messages.ts
+++ b/src/ai/custom-messages.ts
@@ -154,4 +154,3 @@ export
     ErrorMessage,
     ToolProgressMessage,
 };
-

--- a/src/ai/custom-messages.ts
+++ b/src/ai/custom-messages.ts
@@ -154,3 +154,4 @@ export
     ErrorMessage,
     ToolProgressMessage,
 };
+

--- a/src/ai/tools/node-tool-provider.ts
+++ b/src/ai/tools/node-tool-provider.ts
@@ -13,9 +13,9 @@ class NodeToolProvider implements IToolProvider
 
         return {
             ...getFileSystemTools(props),
-            ...getCommandExecutionTools(props),
             ...getClipboardTools(), // Clipboard tools are always available (non-destructive)
             ...getGitTools(props),
+            ...getCommandExecutionTools(props),
         };
     }
 }

--- a/src/ai/work.ts
+++ b/src/ai/work.ts
@@ -11,12 +11,13 @@ interface WorkProps
     chatService: ChatService;
     session: IChatSession;
     send?: (messages: TMessage[]) => void;
+    streaming?: boolean;
     signal?: AbortSignal;
 }
 
 async function work(props: WorkProps)
 {
-    const { session, chatService, send, signal } = props;
+    const { session, chatService, send, streaming = true, signal } = props;
 
     const messages = await workTools({ ...props, session });
 
@@ -25,34 +26,49 @@ async function work(props: WorkProps)
         return messages;
     }
 
-    const { result: stream, error } = await tryCatch(chatService.stream(session, signal));
-
-    if (!stream)
-    {
-        messages.push(new ErrorMessage(`ERROR: ${error?.message || error?.toString() || "llm.stream(...) failed."}`, error));
-        return messages;
-    }
-
     let aiMessage: AIMessageChunk | undefined = undefined;
     let toolProgressMessages: ToolProgressMessage[] = [];
 
-    for await (const chunk of stream)
+    if (streaming)
     {
-        aiMessage = aiMessage !== undefined ? concat(aiMessage, chunk) : chunk;
+        const { result: stream, error } = await tryCatch(chatService.stream(session, signal));
 
-        if (!aiMessage?.tool_calls?.length && !aiMessage?.tool_call_chunks?.length)
+        if (!stream)
         {
-            send?.([...messages, aiMessage]); // TODO: check for race conditions
+            messages.push(new ErrorMessage(`ERROR: ${error?.message || error?.toString() || "llm.stream(...) failed."}`, error));
+            return messages;
         }
-        else
-        {
-            toolProgressMessages = ToolProgressMessage.createFromChunks(aiMessage.tool_call_chunks);
 
-            if (toolProgressMessages.length)
+        for await (const chunk of stream)
+        {
+            aiMessage = aiMessage !== undefined ? concat(aiMessage, chunk) : chunk;
+
+            if (!aiMessage?.tool_calls?.length && !aiMessage?.tool_call_chunks?.length)
             {
-                send?.([...messages, aiMessage, ...toolProgressMessages]);
+                send?.([...messages, aiMessage]); // TODO: check for race conditions
+            }
+            else
+            {
+                toolProgressMessages = ToolProgressMessage.createFromChunks(aiMessage.tool_call_chunks);
+
+                if (toolProgressMessages.length)
+                {
+                    send?.([...messages, aiMessage, ...toolProgressMessages]);
+                }
             }
         }
+    }
+    else
+    {
+        const { result, error } = await tryCatch(chatService.generate(session, signal));
+
+        if (!result || error)
+        {
+            messages.push(new ErrorMessage(`ERROR: ${error?.message || error?.toString() || "llm.generate(...) failed."}`, error));
+            return messages;
+        }
+
+        aiMessage = result;
     }
 
     if (aiMessage)

--- a/src/coba.tsx
+++ b/src/coba.tsx
@@ -14,10 +14,10 @@ program
 
 program
     .command("chat", { isDefault: true })
+    .description(`Start an interactive chat session with ${getAppTitle()}.`)
     .configureHelp({
         commandUsage: () => `${program.name()} [options]`,
     })
-    .description(`Start an interactive chat session with ${getAppTitle()}.`)
     .requiredOption("-p, --provider <provider>", "Specify the model provider to be used", process.env["CODE_BANDIT_PROVIDER"])
     .requiredOption("-m, --model <model>", "Specify the model to be used", process.env["CODE_BANDIT_MODEL"])
     .option("-u, --api-url <url>", "API URL for the model provider")

--- a/src/coba.tsx
+++ b/src/coba.tsx
@@ -2,7 +2,7 @@
 import { Command } from "commander";
 
 import { COMMIT_HASH, VERSION } from "./.version.js";
-import { chat, exec } from "./commands/chat.js";
+import { addChatCommands } from "./commands/chat.js";
 import { installVscodeExtension } from "./commands/install-extension.js";
 import { getAppTitle } from "./utils/info.js";
 
@@ -12,40 +12,7 @@ program
     .name("coba")
     .version(`${VERSION}+${COMMIT_HASH}`);
 
-program
-    .command("chat", { isDefault: true })
-    .description(`Start an interactive chat session with ${getAppTitle()}.`)
-    .configureHelp({
-        commandUsage: () => `${program.name()} [options]`,
-    })
-    .requiredOption("-p, --provider <provider>", "Specify the model provider to be used", process.env["CODE_BANDIT_PROVIDER"])
-    .requiredOption("-m, --model <model>", "Specify the model to be used", process.env["CODE_BANDIT_MODEL"])
-    .option("-u, --api-url <url>", "API URL for the model provider")
-    .option("-k, --api-key <key>", "API key for the model provider")
-    .option("--context-size <size>", "Context size in tokens used for chat history")
-    .option("--max-messages <count>", "Maximum number of messages to keep in chat history", "10")
-    .option("-C, --continue-session <filename>", "Continue with session loaded from filename")
-    .option("--start-message <message>", "Start chat with this message")
-    .option("--read-only", "Start with read-only mode for tools")
-    .option("--write-mode", "Enable (destructive!) write mode for tools")
-    .option("-R, --repo-path <path>", "The git repository directory to work in", ".")
-    .option("--no-agent-rules", "Disable loading of AGENTS.md, .cursorrules, etc.")
-    .option("--debug", "Show debug information")
-    .action(async (options) =>
-    {
-        return chat(options);
-    });
-
-program
-    .command("exec <message...>")
-    .description(`Run ${getAppTitle()} non-interactively.`)
-    .requiredOption("-p, --provider <provider>", "Specify the model provider to be used", process.env["CODE_BANDIT_PROVIDER"])
-    .requiredOption("-m, --model <model>", "Specify the model to be used", process.env["CODE_BANDIT_MODEL"])
-    .action(async (messages: string[], options) =>
-    {
-        const answer = await exec(messages.join(" "), options);
-        console.log(answer);
-    });
+addChatCommands(program);
 
 program
     .command("install-extension")

--- a/src/coba.tsx
+++ b/src/coba.tsx
@@ -2,7 +2,7 @@
 import { Command } from "commander";
 
 import { COMMIT_HASH, VERSION } from "./.version.js";
-import { chat } from "./commands/chat.js";
+import { chat, exec } from "./commands/chat.js";
 import { installVscodeExtension } from "./commands/install-extension.js";
 import { getAppTitle } from "./utils/info.js";
 
@@ -34,6 +34,17 @@ program
     .action(async (options) =>
     {
         return chat(options);
+    });
+
+program
+    .command("exec <message...>")
+    .description("Run ")
+    .requiredOption("-p, --provider <provider>", "Specify the model provider to be used", process.env["CODE_BANDIT_PROVIDER"])
+    .requiredOption("-m, --model <model>", "Specify the model to be used", process.env["CODE_BANDIT_MODEL"])
+    .action(async (messages: string[], options) =>
+    {
+        const answer = await exec(messages.join(" "), options);
+        console.log(answer);
     });
 
 program

--- a/src/coba.tsx
+++ b/src/coba.tsx
@@ -38,7 +38,7 @@ program
 
 program
     .command("exec <message...>")
-    .description("Run ")
+    .description(`Run ${getAppTitle()} non-interactively.`)
     .requiredOption("-p, --provider <provider>", "Specify the model provider to be used", process.env["CODE_BANDIT_PROVIDER"])
     .requiredOption("-m, --model <model>", "Specify the model to be used", process.env["CODE_BANDIT_MODEL"])
     .action(async (messages: string[], options) =>

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -76,20 +76,22 @@ async function exec(message: string, options: any)
 
     const pendingConfirmation = messages.filter(m => ToolProgressMessage.isTypeOf(m)).find(m => m.status === "pending-confirmation");
 
-    const text = messages.filter(m => m instanceof BaseMessage)?.at(-1)?.text;
+    if (pendingConfirmation)
+    {
+        return {
+            error: `ERROR: Pending confirmation for tool "${pendingConfirmation.toolCall?.name}".`,
+            pendingConfirmation,
+            messages,
+        };
+    }
 
-    const error = pendingConfirmation
-        ? `ERROR: Pending confirmation for tool "${pendingConfirmation.toolCall?.name}".`
-        : !text?.length && "No response received.";
+    const text = messages.filter(m => m instanceof BaseMessage)?.at(-1)?.text;
 
     return {
         text,
-        error,
+        error: text?.length,
         messages,
-        pendingConfirmation,
     };
-
-    // // writeFileSync("debug.json", JSON.stringify(messages, null, "  "));
 }
 
 function addChatCommands(program: Command)

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -1,8 +1,8 @@
+import { Command } from "commander";
 import { render } from "ink";
 import { cwd } from "process";
 import React from "react";
 
-import { Command } from "commander";
 import { ChatService, IChatServiceOptions } from "../ai/chat-service.js";
 import { resolveWithinWorkDir } from "../ai/tools/utils.js";
 import { BaseMessage, FileSessionStorage, HumanMessage, NodeToolProvider, PromptLoader, TToolMode, work } from "../index.node.js";
@@ -92,7 +92,7 @@ function addChatCommands(program: Command)
             .option("-R, --repo-path <path>", "The git repository directory to work in", ".")
             .option("--no-agent-rules", "Disable loading of AGENTS.md, .cursorrules, etc.")
             .option("--debug", "Show debug information");
-    }
+    };
 
     addSharedOptions(program.command("chat", { isDefault: true }))
         .description(`Start an interactive chat session with ${getAppTitle()}.`)
@@ -117,5 +117,5 @@ function addChatCommands(program: Command)
 
 export
 {
-    addChatCommands
+    addChatCommands,
 };

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -126,12 +126,27 @@ function addChatCommands(program: Command)
 
     addSharedOptions(program.command("exec <message...>"))
         .description(`Run ${getAppTitle()} non-interactively.`)
+        .option("-o <file>", "Write output to file")
         .action(async (messages: string[], options) =>
         {
             const { text, error } = await exec(messages.join(" "), options);
 
-            error && console.error(error);
-            text && console.log(text);
+            if (error)
+            {
+                console.error(error);
+            }
+
+            if (text)
+            {
+                if (options.o && options.o !== "-")
+                {
+                    await writeFile(options.o, text);
+                }
+                else
+                {
+                    console.log(text);
+                }
+            }
 
             process.exit(error ? -1 : 0);
         });

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -4,6 +4,7 @@ import { cwd } from "process";
 import React from "react";
 
 import { ChatService, IChatServiceOptions } from "../ai/chat-service.js";
+import { ToolProgressMessage } from "../ai/custom-messages.js";
 import { resolveWithinWorkDir } from "../ai/tools/utils.js";
 import { BaseMessage, FileSessionStorage, HumanMessage, NodeToolProvider, PromptLoader, TToolMode, work } from "../index.node.js";
 import ChatApp from "../ui/chat-app.js";
@@ -72,6 +73,13 @@ async function exec(message: string, options: any)
         session,
     });
 
+    const pendingConfirmation = messages.find(m => ToolProgressMessage.isTypeOf(m) && m.status === "pending-confirmation") as ToolProgressMessage | undefined;
+
+    if (pendingConfirmation)
+    {
+        return `ERROR: Pending confirmation for tool "${pendingConfirmation.toolCall?.name}".`;
+    }
+
     return messages.filter(m => m instanceof BaseMessage)?.slice(-1)?.[0]?.text
         || "ERROR: No reply received.";
 }
@@ -117,5 +125,6 @@ function addChatCommands(program: Command)
 
 export
 {
-    addChatCommands,
+    addChatCommands
 };
+

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -4,10 +4,10 @@ import React from "react";
 
 import { ChatService, IChatServiceOptions } from "../ai/chat-service.js";
 import { resolveWithinWorkDir } from "../ai/tools/utils.js";
-import { FileSessionStorage, NodeToolProvider, PromptLoader, TToolMode } from "../index.node.js";
+import { BaseMessage, FileSessionStorage, HumanMessage, NodeToolProvider, PromptLoader, TToolMode, work } from "../index.node.js";
 import ChatApp from "../ui/chat-app.js";
 
-async function chat(options: any)
+async function initChatSession(options: any)
 {
     const gitRepoPath = resolveWithinWorkDir(".", options.repoPath || ".");
 
@@ -44,9 +44,34 @@ async function chat(options: any)
         toolProvider: new NodeToolProvider(),
     });
 
+    return {
+        chatService,
+        session,
+    };
+}
+
+async function chat(options: any)
+{
+    const { session, chatService } = await initChatSession(options);
+
     const props = { chatService, session, startMessage: options.startMessage, debug: options.debug };
 
     render(<ChatApp {...props} />, { exitOnCtrlC: false });
 }
 
-export { chat };
+async function exec(message: string, options: any)
+{
+    const { chatService, session } = await initChatSession(options);
+
+    session.messages.push(new HumanMessage(message));
+
+    const messages = await work({
+        chatService,
+        session,
+    });
+
+    return messages.filter(m => m instanceof BaseMessage)?.slice(-1)?.[0]?.text
+        || "ERROR: No reply received.";
+}
+
+export { chat, exec };

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -2,10 +2,12 @@ import { render } from "ink";
 import { cwd } from "process";
 import React from "react";
 
+import { Command } from "commander";
 import { ChatService, IChatServiceOptions } from "../ai/chat-service.js";
 import { resolveWithinWorkDir } from "../ai/tools/utils.js";
 import { BaseMessage, FileSessionStorage, HumanMessage, NodeToolProvider, PromptLoader, TToolMode, work } from "../index.node.js";
 import ChatApp from "../ui/chat-app.js";
+import { getAppTitle } from "../utils/info.js";
 
 async function initChatSession(options: any)
 {
@@ -74,9 +76,46 @@ async function exec(message: string, options: any)
         || "ERROR: No reply received.";
 }
 
+function addChatCommands(program: Command)
+{
+    const addSharedOptions = (command: Command) => 
+    {
+        return command
+            .requiredOption("-p, --provider <provider>", "Specify the model provider to be used", process.env["CODE_BANDIT_PROVIDER"])
+            .requiredOption("-m, --model <model>", "Specify the model to be used", process.env["CODE_BANDIT_MODEL"])
+            .option("-u, --api-url <url>", "API URL for the model provider")
+            .option("-k, --api-key <key>", "API key for the model provider")
+            .option("--context-size <size>", "Context size in tokens used for chat history")
+            .option("--max-messages <count>", "Maximum number of messages to keep in chat history", "10")
+            .option("--read-only", "Start with read-only mode for tools")
+            .option("--write-mode", "Enable (destructive!) write mode for tools")
+            .option("-R, --repo-path <path>", "The git repository directory to work in", ".")
+            .option("--no-agent-rules", "Disable loading of AGENTS.md, .cursorrules, etc.")
+            .option("--debug", "Show debug information");
+    }
+
+    addSharedOptions(program.command("chat", { isDefault: true }))
+        .description(`Start an interactive chat session with ${getAppTitle()}.`)
+        .configureHelp({
+            commandUsage: () => `${program.name()} [options]`,
+        })
+        .option("-C, --continue-session <filename>", "Continue with session loaded from filename")
+        .option("--start-message <message>", "Start chat with this message")
+        .action(async (options) =>
+        {
+            return chat(options);
+        });
+
+    addSharedOptions(program.command("exec <message...>"))
+        .description(`Run ${getAppTitle()} non-interactively.`)
+        .action(async (messages: string[], options) =>
+        {
+            const answer = await exec(messages.join(" "), options);
+            console.log(answer);
+        });
+}
+
 export
 {
-    chat,
-    exec,
+    addChatCommands
 };
-

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -125,6 +125,6 @@ function addChatCommands(program: Command)
 
 export
 {
-    addChatCommands
+    addChatCommands,
 };
 

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -74,4 +74,9 @@ async function exec(message: string, options: any)
         || "ERROR: No reply received.";
 }
 
-export { chat, exec };
+export
+{
+    chat,
+    exec,
+};
+

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -71,17 +71,25 @@ async function exec(message: string, options: any)
     const messages = await work({
         chatService,
         session,
+        streaming: false,
     });
 
-    const pendingConfirmation = messages.find(m => ToolProgressMessage.isTypeOf(m) && m.status === "pending-confirmation") as ToolProgressMessage | undefined;
+    const pendingConfirmation = messages.filter(m => ToolProgressMessage.isTypeOf(m)).find(m => m.status === "pending-confirmation");
 
-    if (pendingConfirmation)
-    {
-        return `ERROR: Pending confirmation for tool "${pendingConfirmation.toolCall?.name}".`;
-    }
+    const text = messages.filter(m => m instanceof BaseMessage)?.at(-1)?.text;
 
-    return messages.filter(m => m instanceof BaseMessage)?.slice(-1)?.[0]?.text
-        || "ERROR: No reply received.";
+    const error = pendingConfirmation
+        ? `ERROR: Pending confirmation for tool "${pendingConfirmation.toolCall?.name}".`
+        : !text?.length && "No response received.";
+
+    return {
+        text,
+        error,
+        messages,
+        pendingConfirmation,
+    };
+
+    // // writeFileSync("debug.json", JSON.stringify(messages, null, "  "));
 }
 
 function addChatCommands(program: Command)
@@ -118,8 +126,12 @@ function addChatCommands(program: Command)
         .description(`Run ${getAppTitle()} non-interactively.`)
         .action(async (messages: string[], options) =>
         {
-            const answer = await exec(messages.join(" "), options);
-            console.log(answer);
+            const { text, error } = await exec(messages.join(" "), options);
+
+            error && console.error(error);
+            text && console.log(text);
+
+            process.exit(error ? -1 : 0);
         });
 }
 

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -80,7 +80,7 @@ async function exec(message: string, options: any)
     if (pendingConfirmation)
     {
         return {
-            error: `ERROR: Pending confirmation for tool "${pendingConfirmation.toolCall?.name}".`,
+            error: `Pending confirmation for tool "${pendingConfirmation.toolCall?.name}".`,
             pendingConfirmation,
             messages,
         };
@@ -90,7 +90,7 @@ async function exec(message: string, options: any)
 
     return {
         text,
-        error: text?.length,
+        error: text?.length === 0 ? "Empty response." : undefined,
         messages,
     };
 }
@@ -134,7 +134,7 @@ function addChatCommands(program: Command)
 
             if (error)
             {
-                console.error(error);
+                console.error(`ERROR: ${error}`);
             }
 
             if (text)

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { writeFile } from "fs/promises";
 import { render } from "ink";
 import { cwd } from "process";
 import React from "react";


### PR DESCRIPTION
This pull request introduces a non-interactive `exec` command and refactors the command-line interface for better organization.

### ✨ New Features

*   **Non-Interactive Mode**: A new `exec` command has been added to allow for non-interactive execution of commands (e.g., `coba exec "Refactor this function"`). This is useful for scripting and single-shot commands, with output optionally written to a file using the `-o` flag.
*   **Command-Line Interface Refactoring**: The command-line interface definition has been refactored into a dedicated `addChatCommands` function to improve code organization and reduce duplication.

### ⚙️ Under the Hood

*   **Shared Options**: A new `addSharedOptions` function has been created to centralize the command-line options for both the `chat` and new `exec` commands, ensuring consistency and reducing boilerplate.
*   **Session Initialization**: The chat session setup logic has been extracted into a new `initChatSession` function, which is now used by both commands.
*   **Non-Streaming AI Calls**: The core `work` function and `ChatService` now support a non-streaming mode (`streaming: false`) for the `exec` command, which waits for the complete response from the AI model instead of processing a stream.