### PR TITLE
feat: add optional non-streaming mode for interactive chat

### DIFF
--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -59,7 +59,13 @@ async function chat(options: any)
 {
     const { session, chatService } = await initChatSession(options);
 
-    const props = { chatService, session, startMessage: options.startMessage, debug: options.debug };
+    const props = {
+        chatService,
+        session,
+        startMessage: options.startMessage,
+        disableStreaming: options.stream === false,
+        debug: options.debug,
+    };
 
     render(<ChatApp {...props} />, { exitOnCtrlC: false });
 }
@@ -121,6 +127,7 @@ function addChatCommands(program: Command)
         })
         .option("-C, --continue-session <filename>", "Continue with session loaded from filename")
         .option("--start-message <message>", "Start chat with this message")
+        .option("--no-stream", "Disable streaming responses")
         .action(async (options) =>
         {
             return chat(options);
@@ -170,3 +177,4 @@ export
 {
     addChatCommands,
 };
+

--- a/src/commands/chat.tsx
+++ b/src/commands/chat.tsx
@@ -63,7 +63,7 @@ async function chat(options: any)
         chatService,
         session,
         startMessage: options.startMessage,
-        disableStreaming: options.stream === false,
+        streaming: options.stream !== false,
         debug: options.debug,
     };
 
@@ -177,4 +177,3 @@ export
 {
     addChatCommands,
 };
-

--- a/src/ui/chat-app.tsx
+++ b/src/ui/chat-app.tsx
@@ -18,12 +18,13 @@ interface ChatAppProps
     chatService: ChatService;
     session: ChatSession;
     startMessage?: string;
+    disableStreaming?: boolean;
     debug?: boolean;
 }
 
 function ChatApp(props: ChatAppProps)
 {
-    const { chatService, session, startMessage, debug } = props;
+    const { chatService, session, startMessage, disableStreaming, debug } = props;
     const { chatServiceOptions } = session;
 
     const [_message, setMessage] = useState("");
@@ -38,6 +39,7 @@ function ChatApp(props: ChatAppProps)
     } = useChatController({
         chatService,
         session,
+        disableStreaming,
     });
 
     useEffect(() =>

--- a/src/ui/chat-app.tsx
+++ b/src/ui/chat-app.tsx
@@ -18,13 +18,13 @@ interface ChatAppProps
     chatService: ChatService;
     session: ChatSession;
     startMessage?: string;
-    disableStreaming?: boolean;
+    streaming?: boolean;
     debug?: boolean;
 }
 
 function ChatApp(props: ChatAppProps)
 {
-    const { chatService, session, startMessage, disableStreaming, debug } = props;
+    const { chatService, session, startMessage, streaming = true, debug } = props;
     const { chatServiceOptions } = session;
 
     const [_message, setMessage] = useState("");
@@ -39,7 +39,7 @@ function ChatApp(props: ChatAppProps)
     } = useChatController({
         chatService,
         session,
-        disableStreaming,
+        streaming,
     });
 
     useEffect(() =>

--- a/src/ui/chat-controller.ts
+++ b/src/ui/chat-controller.ts
@@ -10,12 +10,12 @@ interface UseChatControllerProps
 {
     chatService: ChatService;
     session: ChatSession;
-    disableStreaming?: boolean;
+    streaming?: boolean;
 }
 
 export function useChatController(props: UseChatControllerProps)
 {
-    const { chatService, session, disableStreaming } = props;
+    const { chatService, session, streaming = true } = props;
 
     const { exit } = useApp();
 
@@ -48,7 +48,7 @@ export function useChatController(props: UseChatControllerProps)
         work({
             chatService,
             session,
-            streaming: !disableStreaming,
+            streaming,
             send: (messages: TMessage[]) => setChatHistory(history => ({ ...history, messages })),
             signal: abortController.signal,
         })

--- a/src/ui/chat-controller.ts
+++ b/src/ui/chat-controller.ts
@@ -10,11 +10,12 @@ interface UseChatControllerProps
 {
     chatService: ChatService;
     session: ChatSession;
+    disableStreaming?: boolean;
 }
 
 export function useChatController(props: UseChatControllerProps)
 {
-    const { chatService, session } = props;
+    const { chatService, session, disableStreaming } = props;
 
     const { exit } = useApp();
 
@@ -47,6 +48,7 @@ export function useChatController(props: UseChatControllerProps)
         work({
             chatService,
             session,
+            streaming: !disableStreaming,
             send: (messages: TMessage[]) => setChatHistory(history => ({ ...history, messages })),
             signal: abortController.signal,
         })


### PR DESCRIPTION
New Features
- chat command: add --no-stream flag to disable streaming responses for interactive sessions.
- Interactive UI now supports both streaming and non-streaming inference paths.

Under the Hood
- Thread a streaming?: boolean flag through the interactive stack:
  - src/commands/chat.tsx: pass streaming: options.stream !== false to ChatApp props; add CLI option --no-stream.
  - src/ui/chat-app.tsx: add streaming prop (default true) and forward to controller.
  - src/ui/chat-controller.ts: accept streaming prop (default true) and pass to work({...}).
- No changes to IChatSession or IChatServiceOptions; streaming is treated strictly as a runtime/UI concern.
- Default behavior remains unchanged (streaming enabled) unless --no-stream is provided.

Documentation
- CLI help updated: chat now documents --no-stream.

Risk and Rollback
- Risk: Low. The default remains streaming enabled; the new path is guarded by an explicit flag.
- Known risk areas:
  - Non-streaming interactive flow relies on work(..., streaming: false); ensure tool call progress updates still render (workTools continues to emit via send).
- Rollback plan: Revert this PR; behavior returns to always-streaming interactive output.
- Mitigations/validation:
  - Manual test:
    - chat (default): verify streaming output updates in real-time.
    - chat --no-stream: verify output appears after completion and tool confirmations still function.
    - exec: unchanged; remains non-streaming.