### PR TITLE
fix: add rule to disallow invalid usage of 'this' in TypeScript files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,6 +39,8 @@ export default [
                 format: ["camelCase", "PascalCase"],
             }],
 
+            "@typescript-eslint/no-invalid-this": ["error"],
+
             "@stylistic/brace-style": ["error", "allman", { allowSingleLine: true }],
             "@stylistic/quotes": ["error", "double"],
             "@stylistic/comma-dangle": ["error", "always-multiline"],


### PR DESCRIPTION
This pull request introduces the `@typescript-eslint/no-invalid-this` ESLint rule to enhance code quality by disallowing the use of `this` in contexts where it is invalid.

### ⚙️ Under the Hood

- Enabled the `@typescript-eslint/no-invalid-this` rule in `eslint.config.js`.
